### PR TITLE
Fix "underflow" problem when updating CHANGELOG

### DIFF
--- a/changelog_tool.pony
+++ b/changelog_tool.pony
@@ -54,6 +54,7 @@ class ChangelogTool
     if edit then
       with file = File(_filepath) do
         file
+          .> set_length(0)
           .> write(s)
           .> flush()
       end


### PR DESCRIPTION
I encountered a problem where the end of the CHANGELOG would be
"duplicated" at the end. This would occur when an update caused the file
to shrink. Because we didn't zero out the file first, the older "long
content" would still be displayed at the end of the file.