### PR TITLE
Check for single release node as AST

### DIFF
--- a/changelog.pony
+++ b/changelog.pony
@@ -5,15 +5,21 @@ class Changelog
   let released: Array[Release]
 
   new create(ast: AST) ? =>
-    let children = ast.children.values()
-    released = Array[Release](ast.size())
-    if ast.size() > 0 then
-      unreleased = try Release(children.next()? as AST)? end
-      for child in children do
-        released.push(Release(child as AST)?)
-      end
+    match ast.label()
+    | let _: TRelease =>
+      unreleased = Release(ast)?
+      released = Array[Release]
     else
-      unreleased = None
+      let children = ast.children.values()
+      released = Array[Release](ast.size())
+      if ast.size() > 0 then
+        unreleased = try Release(children.next()? as AST)? end
+        for child in children do
+          released.push(Release(child as AST)?)
+        end
+      else
+        unreleased = None
+      end
     end
 
   new _create(unreleased': (Release | None), released': Array[Release]) =>


### PR DESCRIPTION
This change adds a check for a single release node as the given AST
to the Changelog constructor.
Resolves #10.