### PR TITLE
Allow any text for the heading

### DIFF
--- a/changelog_parser.pony
+++ b/changelog_parser.pony
@@ -3,8 +3,13 @@ use "peg"
 primitive ChangelogParser
   fun apply(): Parser val =>
     recover
-      let heading = L(_Util.changelog_heading())
-      -heading * -L("\n").many1() * release(false).opt() * release().many()
+      head() * release(false).opt() * release().many()
+    end
+
+  fun head(): Parser val =>
+    recover
+      (not L("\n## [") * Unicode).many().term(THeading)
+        * -L("\n").opt()
     end
 
   fun release(released: Bool = true): Parser val =>
@@ -56,6 +61,8 @@ primitive ChangelogParser
 
   fun digit(): Parser val => recover R('0', '9') end
 
+primitive THeading is Label fun text(): String => "Heading"
+
 trait val TSection is Label
 primitive Fixed is TSection fun text(): String => "Fixed"
 primitive Added is TSection fun text(): String => "Added"
@@ -65,7 +72,3 @@ primitive TRelease is Label fun text(): String => "Release"
 primitive TVersion is Label fun text(): String => "Version"
 primitive TDate is Label fun text(): String => "Date"
 primitive TEntries is Label fun text(): String => "Entries"
-
-primitive _Util
-  fun changelog_heading(): String =>
-    "# Change Log\n\nAll notable changes to the Pony compiler and standard library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).\n"

--- a/changelog_tool.pony
+++ b/changelog_tool.pony
@@ -23,7 +23,7 @@ class ChangelogTool
       let date = Date(Time.seconds()).format("%Y-%m-%d")
       let changelog: String =
         Changelog(_parse()?)?
-          .create_release(version, date)?
+          .> create_release(version, date)?
           .string()
       _edit_or_print(edit, changelog)
     else
@@ -43,7 +43,7 @@ class ChangelogTool
     try
       let changelog: String =
         Changelog(_parse()?)?
-          .create_unreleased()
+          .> create_unreleased()
           .string()
       _edit_or_print(edit, changelog)
     else
@@ -66,7 +66,7 @@ class ChangelogTool
     let source = Source(FilePath(_env.root as AmbientAuth, _filename)?)?
     match recover val ChangelogParser().parse(source) end
     | (_, let ast: AST) =>
-      //_env.out.print(recover val Printer(ast) end)
+      // _env.out.print(recover val Printer(ast) end)
       ast
     | (let offset: USize, let r: Parser val) =>
       let e = recover val SyntaxError(source, offset, r) end

--- a/tests/main.pony
+++ b/tests/main.pony
@@ -10,31 +10,10 @@ actor Main is TestList
     test(_TestParseVersion)
     test(_TestParseDate)
     test(_TestParseEntries)
+    test(_TestParseHead)
     test(_TestParseChangelog)
+    test(_TestSingleRelease)
 
-class ParseTest
-  let _h: TestHelper
-  let _parser: Parser
-
-  new create(h: TestHelper, parser: Parser) =>
-    (_h, _parser) = (h, parser)
-
-  fun run(tests: Array[(String, String)]) =>
-    for (source, expected) in tests.values() do
-      _h.log("test: " + source)
-      let source' = Source.from_string(source)
-      match recover val _parser.parse(source') end
-      | (_, let r: (AST | Token | NotPresent)) =>
-        let result = recover val Printer(r) end
-        _h.assert_eq[String](expected, result)
-      | (let offset: USize, let r: Parser val) =>
-        let e = recover val SyntaxError(source', offset, r) end
-        _Logv(_h, PegFormatError.console(e))
-        _h.assert_eq[String](expected, "")
-      | (_, Skipped) => _h.log("skipped")
-      | (_, Lex) => _h.log("lex")
-      end
-    end
 
 class iso _TestParseVersion is UnitTest
   fun name(): String => "parse version"
@@ -83,6 +62,52 @@ class iso _TestParseEntries is UnitTest
           "(Entries - Upgrade to LLVM 3.9.1 ([PR #1498](https://github.com/ponylang/ponyc/pull/1498)))\n" )
       ])
 
+class iso _TestParseHead is UnitTest
+  fun name(): String => "parse heading"
+
+  fun apply(h: TestHelper) =>
+    ParseTest(h, ChangelogParser.head()).run(
+      [ ( """
+          # Change Log
+
+          All notable changes to the Pony compiler and standard library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
+          """,
+          """
+          (Heading # Change Log
+
+          All notable changes to the Pony compiler and standard library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
+          )
+          """)
+        ( """
+          # Change Log
+
+          Some other text
+
+          ## [unreleased] - unreleased
+          """,
+          """
+          (Heading # Change Log
+
+          Some other text
+          )
+          """ )
+        ( """
+          # Change Log
+
+          Some other text that contains:
+          `## [unreleased] - unreleased`
+
+          ## [unreleased] - unreleased
+          """,
+          """
+          (Heading # Change Log
+
+          Some other text that contains:
+          `## [unreleased] - unreleased`
+          )
+          """ )
+      ])
+
 class iso _TestParseChangelog is UnitTest
   fun name(): String => "parse CHANGELOG"
 
@@ -112,6 +137,96 @@ class iso _TestParseChangelog is UnitTest
       end
     else
       h.fail()
+    end
+
+class iso _TestSingleRelease is UnitTest
+  fun name(): String => "single release"
+
+  fun apply(h: TestHelper) ? =>
+    _OutputTest(h, ChangelogParser()).run(
+      """
+      # Change Log
+
+      All notable changes to the Pony compiler and standard library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
+
+      ## [unreleased] - unreleased
+
+      ### Fixed
+
+      - Fix invalid separator in PONYPATH for Windows. ([PR #32](https://github.com/ponylang/pony-stable/pull/32))
+
+      ### Added
+
+
+
+      ### Changed
+
+
+      """,
+      """
+      # Change Log
+
+      All notable changes to the Pony compiler and standard library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
+
+      ## [0.0.0] - 0000-00-00
+
+      ### Fixed
+
+      - Fix invalid separator in PONYPATH for Windows. ([PR #32](https://github.com/ponylang/pony-stable/pull/32))
+
+      """)?
+
+class ParseTest
+  let _h: TestHelper
+  let _parser: Parser
+
+  new create(h: TestHelper, parser: Parser) =>
+    (_h, _parser) = (h, parser)
+
+  fun run(tests: Array[(String, String)]) =>
+    for (source, expected) in tests.values() do
+      _h.log("test: " + source)
+      let source' = Source.from_string(source)
+      match recover val _parser.parse(source') end
+      | (_, let r: (AST | Token | NotPresent)) =>
+        let result = recover val Printer(r) end
+        _h.assert_eq[String](expected, result)
+      | (let offset: USize, let r: Parser val) =>
+        let e = recover val SyntaxError(source', offset, r) end
+        _Logv(_h, PegFormatError.console(e))
+        _h.assert_eq[String](expected, "")
+      | (_, Skipped) => _h.log("skipped")
+      | (_, Lex) => _h.log("lex")
+      end
+    end
+
+class _OutputTest
+  let _h: TestHelper
+  let _parser: Parser
+
+  new create(h: TestHelper, parser: Parser) =>
+    (_h, _parser) = (h, parser)
+
+  fun run(input: String, expected: String) ? =>
+    let source = Source.from_string(input)
+    match recover val _parser.parse(source) end
+    | (let n: USize, let r: (AST | Token | NotPresent)) =>
+      match r
+      | let ast: AST =>
+        let changelog =
+          Changelog(ast)? .> create_release("0.0.0", "0000-00-00")?
+        let output: String = changelog.string()
+        _h.log(recover val Printer(ast) end)
+        _h.log(output)
+        _h.assert_eq[String](expected, output)
+      else
+        _h.log(recover val Printer(r) end)
+        _h.fail()
+      end
+    | (let offset: USize, let r: Parser val) =>
+      let e = recover val SyntaxError(source, offset, r) end
+      _Logv(_h, PegFormatError.console(e))
+      _h.fail()
     end
 
 primitive _Logv


### PR DESCRIPTION
This change allows any text to be included after `# Change Log` and
before the first release node. This closes #12 and also closes #10 by
making a single release AST impossible since the heading is now its
own node.