### PR TITLE
Improve changelog grammar

### DIFF
--- a/changelog_tool.pony
+++ b/changelog_tool.pony
@@ -13,7 +13,14 @@ class ChangelogTool
   fun verify() =>
     _env.out.print("verifying " + _filename + "...")
     try
-      _parse()?
+      let ast = _parse()?
+
+      // TODO:
+      // let changelog = Changelog(ast)?
+      // _env.out.print(changelog.string())
+      // try changelog .> create_release("0.0.0", "0000-00-00")
+      // else _env.out.print("fail.")
+      // end
       _env.out.print(_filename + " is a valid changelog")
     end
 
@@ -23,7 +30,7 @@ class ChangelogTool
       let date = Date(Time.seconds()).format("%Y-%m-%d")
       let changelog: String =
         Changelog(_parse()?)?
-          .> create_release(version, date)?
+          .> create_release(version, date)
           .string()
       _edit_or_print(edit, changelog)
     else

--- a/tests/CHANGELOG.md
+++ b/tests/CHANGELOG.md
@@ -7,13 +7,10 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 
-
 ### Added
 
 
-
 ### Changed
-
 
 
 ## [0.13.0] - 2017-04-07


### PR DESCRIPTION
This PR makes the changelog parser less strict. This includes removing
the requirement for more than one newline after release sections and
allowing entries to be seperated by many newlines.