### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ponylang/ponyc:release
+
+WORKDIR /src/changelog-tool
+
+COPY Makefile LICENSE bundle.json /src/changelog-tool/
+COPY *.pony /src/changelog-tool/
+
+RUN make \
+  && make install \
+  && make clean
+
+WORKDIR /src/main
+
+CMD changelog-tool


### PR DESCRIPTION
Allows for setup of an autobuild of an image on dockerhub that generate
a changelog tool image using the latest release ponyc. Said image will
be used as a step in our circle-ci workflow to validate that our
changelog is valid on each PR.