### PR TITLE
Add "add" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ changelog-tool get 0.2.2
 changelog-tool unreleased -e
 ```
 
+## Add an entry to an unreleased section
+```bash
+changelog-tool add fixed "We fixed some bad issues" -e
+changelog-tool add added "We just added some new cool stuff" -e
+changelog-tool add changed "And changed things a bit" -e
+```
+
 ## Prepare a Changelog for a Release
 
 ```bash

--- a/changelog-tool/changelog.pony
+++ b/changelog-tool/changelog.pony
@@ -1,5 +1,4 @@
 use "peg"
-use "debug"
 
 class Changelog
   let heading: String
@@ -105,20 +104,23 @@ class Release
     // In order to represent the empty sections of unreleased releases,
     // we must use the empty correspoding section when printing instead
     // of None, otherwise it will be ignored.
-    let fixed' = match fixed
-    | None if heading == _unreleased_heading => Section._empty(Fixed)
-    else fixed
-    end
+    let fixed' =
+      match fixed
+        | None if heading == _unreleased_heading => Section._empty(Fixed)
+      else fixed
+      end
 
-    let added' = match added
-    | None if heading == _unreleased_heading => Section._empty(Added)
-    else added
-    end
+    let added' =
+      match added
+    |   None if heading == _unreleased_heading => Section._empty(Added)
+      else added
+      end
 
-    let changed' = match changed
-    | None if heading == _unreleased_heading => Section._empty(Changed)
-    else changed
-    end
+    let changed' =
+      match changed
+      | None if heading == _unreleased_heading => Section._empty(Changed)
+      else changed
+      end
 
     let str = recover String .> append(heading) .> append("\n\n") end
     for section in [fixed'; added'; changed'].values() do

--- a/changelog-tool/changelog.pony
+++ b/changelog-tool/changelog.pony
@@ -1,4 +1,5 @@
 use "peg"
+use "debug"
 
 class Changelog
   let heading: String
@@ -101,8 +102,26 @@ class Release
     section.entries.push("- " + entry)
 
   fun string(): String iso^ =>
+    // In order to represent the empty sections of unreleased releases,
+    // we must use the empty correspoding section when printing instead
+    // of None, otherwise it will be ignored.
+    let fixed' = match fixed
+    | None if heading == _unreleased_heading => Section._empty(Fixed)
+    else fixed
+    end
+
+    let added' = match added
+    | None if heading == _unreleased_heading => Section._empty(Added)
+    else added
+    end
+
+    let changed' = match changed
+    | None if heading == _unreleased_heading => Section._empty(Changed)
+    else changed
+    end
+
     let str = recover String .> append(heading) .> append("\n\n") end
-    for section in [fixed; added; changed].values() do
+    for section in [fixed'; added'; changed'].values() do
       match section
       | let s: Section box =>
         str .> append(s.string()) .> append("\n")

--- a/changelog-tool/changelog.pony
+++ b/changelog-tool/changelog.pony
@@ -45,6 +45,11 @@ class Changelog
       unreleased = Release._unreleased()
     end
 
+  fun ref add_entry(section_name: String, entry: String) ? =>
+    match unreleased
+    | let r: Release => r.add_entry(section_name, entry)?
+    end
+
   fun string(): String iso^ =>
     let str = (recover String end)
       .> append("# Change Log\n\n")
@@ -79,25 +84,25 @@ class Release
     added = Section._empty(Added)
     changed = Section._empty(Changed)
 
-  fun string(): String iso^ =>
-    if heading == _unreleased_heading then
-      "\n\n".join(
-        [ heading
-          "### Fixed\n"
-          "### Added\n"
-          "### Changed\n"
-          ""
-        ].values())
-    else
-      let str = recover String .> append(heading) .> append("\n\n") end
-      for section in [fixed; added; changed].values() do
-        match section
-        | let s: Section box =>
-          str .> append(s.string()) .> append("\n")
-        end
+  fun ref add_entry(section_name: String, entry: String) ? =>
+    let section =
+      match section_name
+      | "fixed" => try fixed as Section else fixed = Section._empty(Fixed); fixed as Section end
+      | "added" => try added as Section else added = Section._empty(Added); added as Section end
+      | "changed" => try changed as Section else changed = Section._empty(Changed); changed as Section end
+      else error
       end
-      str
+    section.entries.push("- " + entry)
+
+  fun string(): String iso^ =>
+    let str = recover String .> append(heading) .> append("\n\n") end
+    for section in [fixed; added; changed].values() do
+      match section
+      | let s: Section box =>
+        str .> append(s.string()) .> append("\n")
+      end
     end
+    str
 
 class Section
   let label: TSection

--- a/changelog-tool/changelog.pony
+++ b/changelog-tool/changelog.pony
@@ -87,9 +87,15 @@ class Release
   fun ref add_entry(section_name: String, entry: String) ? =>
     let section =
       match section_name
-      | "fixed" => try fixed as Section else fixed = Section._empty(Fixed); fixed as Section end
-      | "added" => try added as Section else added = Section._empty(Added); added as Section end
-      | "changed" => try changed as Section else changed = Section._empty(Changed); changed as Section end
+      | "fixed" =>
+        if fixed is None then fixed = Section._empty(Fixed) end
+        fixed as Section
+      | "added" =>
+        if added is None then added = Section._empty(Added) end
+        added as Section
+      | "changed" =>
+        if changed is None then changed = Section._empty(Changed) end
+        changed as Section
       else error
       end
     section.entries.push("- " + entry)

--- a/changelog-tool/main.pony
+++ b/changelog-tool/main.pony
@@ -70,6 +70,13 @@ actor Main
             ].values()),
           [edit],
           [ArgSpec.string("version")])?
+	CommandSpec.leaf(
+	  "add",
+	  "Add a new entry at the end of the section",
+	  [edit],
+	  [ ArgSpec.string("section")
+            ArgSpec.string("entry")
+	  ])?
       ])?
       .> add_help("help", "Print this message and exit")?
 
@@ -95,6 +102,8 @@ actor Main
     | "changelog-tool/release" =>
       cmd_release(
         path, filename, cmd.arg("version").string(), cmd.option("edit").bool())
+    | "changelog-tool/add" =>
+      cmd_add(path, filename, cmd.arg("section").string(), cmd.arg("entry").string(), cmd.option("edit").bool())
     else
       err("unknown command: " + cmd.fullname())
       please_report()
@@ -169,6 +178,24 @@ actor Main
           .string())
     else
       err("unable to perform release preparation")
+    end
+
+  fun cmd_add(
+    filepath: FilePath,
+    filename: String,
+    section: String,
+    entry: String,
+    edit: Bool)
+  =>
+    try
+      edit_or_print(
+        filepath,
+        edit,
+	Changelog(parse(filepath, filename)?)?
+	  .> add_entry(section, entry)?
+	  .string())
+    else
+      err("unable add a new changelog entry")
     end
 
   fun parse(filepath: FilePath, filename: String): peg.AST ? =>

--- a/changelog-tool/main.pony
+++ b/changelog-tool/main.pony
@@ -75,7 +75,7 @@ actor Main
 	  "Add a new entry at the end of the section",
 	  [edit],
 	  [ ArgSpec.string("section")
-            ArgSpec.string("entry")
+      ArgSpec.string("entry")
 	  ])?
       ])?
       .> add_help("help", "Print this message and exit")?
@@ -103,7 +103,9 @@ actor Main
       cmd_release(
         path, filename, cmd.arg("version").string(), cmd.option("edit").bool())
     | "changelog-tool/add" =>
-      cmd_add(path, filename, cmd.arg("section").string(), cmd.arg("entry").string(), cmd.option("edit").bool())
+      cmd_add(
+        path, filename, cmd.arg("section").string(),
+        cmd.arg("entry").string(),cmd.option("edit").bool())
     else
       err("unknown command: " + cmd.fullname())
       please_report()
@@ -191,9 +193,9 @@ actor Main
       edit_or_print(
         filepath,
         edit,
-	Changelog(parse(filepath, filename)?)?
-	  .> add_entry(section, entry)?
-	  .string())
+        Changelog(parse(filepath, filename)?)?
+          .> add_entry(section, entry)?
+          .string())
     else
       err("unable add a new changelog entry")
     end

--- a/tests/main.pony
+++ b/tests/main.pony
@@ -232,6 +232,39 @@ class iso _TestRelease is UnitTest
 
       """)?
 
+    _ReleaseTestAfterAddingSomeEntries(h, ChangelogParser()).run(
+      """
+      # Change Log
+
+      ## [unreleased] - unreleased
+
+      ### Fixed
+
+      ### Added
+
+      ### Changed
+
+      """,
+      """
+      # Change Log
+
+      ## [0.0.0] - 0000-00-00
+
+      ### Fixed
+
+      - We made some fixes...
+      - Oh, and we made a final one.
+
+      ### Added
+
+      - We added some stuff as well.
+
+      ### Changed
+
+      - And we changed a few things also.
+
+      """)?
+
 class ParseTest
   let _h: TestHelper
   let _parser: Parser
@@ -273,6 +306,40 @@ class _ReleaseTest
         _h.log(recover val _Printer(ast) end)
         // _h.log(Changelog(ast)?.string())
         let changelog = Changelog(ast)? .> create_release("0.0.0", "0000-00-00")
+        let output: String = changelog.string()
+        _h.log(output)
+        _h.assert_eq[String](expected, output)
+      else
+        _h.log(recover val _Printer(r) end)
+        _h.fail()
+      end
+    | (let offset: USize, let r: Parser val) =>
+      let e = recover val SyntaxError(source, offset, r) end
+      _Logv(_h, PegFormatError.console(e))
+      _h.fail()
+    end
+
+class _ReleaseTestAfterAddingSomeEntries
+  let _h: TestHelper
+  let _parser: Parser
+
+  new create(h: TestHelper, parser: Parser) =>
+    (_h, _parser) = (h, parser)
+
+  fun run(input: String, expected: String) ? =>
+    let source = Source.from_string(input)
+    match recover val _parser.parse(source) end
+    | (let n: USize, let r: (AST | Token | NotPresent)) =>
+      match r
+      | let ast: AST =>
+        _h.log(recover val _Printer(ast) end)
+        // _h.log(Changelog(ast)?.string())
+        let changelog = Changelog(ast)?
+          .> add_entry("fixed", "We made some fixes...\n")?
+          .> add_entry("fixed", "Oh, and we made a final one.\n")?
+          .> add_entry("added", "We added some stuff as well.\n")?
+          .> add_entry("changed", "And we changed a few things also.\n")?
+          .> create_release("0.0.0", "0000-00-00")
         let output: String = changelog.string()
         _h.log(output)
         _h.assert_eq[String](expected, output)

--- a/tests/main.pony
+++ b/tests/main.pony
@@ -333,7 +333,6 @@ class _ReleaseTestAfterAddingSomeEntries
       match r
       | let ast: AST =>
         _h.log(recover val _Printer(ast) end)
-        // _h.log(Changelog(ast)?.string())
         let changelog = Changelog(ast)?
           .> add_entry("fixed", "We made some fixes...\n")?
           .> add_entry("fixed", "Oh, and we made a final one.\n")?


### PR DESCRIPTION
The following sequence of commands:

```bash
changelog-tool new
changelog-tool unreleased -e
changelog-tool add fixed "We fixed some nasty bug." -e
changelog-tool add added "And we added some cool feature." -e
changelog-tool add changed "And changed some little things as well." -e
changelog-tool release 1.0.0
```

Will result in this nice changelog:

```markdown
# Change Log

All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).

## [1.0.0] - 2019-11-09

### Fixed

- We fixed some nasty bug.

### Added

- And we added some cool feature.

### Changed

- And changed some little things as well.

```