### PR TITLE
Be consistent in our testing environment

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -1,4 +1,4 @@
-name: Nightly breakage against ponyc:latest
+name: Nightly breakage against ponyc master
 
 on:
   schedule:
@@ -6,11 +6,11 @@ on:
 
 jobs:
   vs-ponyc-master:
-    name: Verify master against ponyc:latest
+    name: Verify master against ponyc master
     runs-on: ubuntu-latest
     container:
-      image: ponylang/ponyc:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
     steps:
       - uses: actions/checkout@v1
-      - name: Test with ponyc:latest
+      - name: Test with against ponyc master
         run: make test

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
     steps:
       - uses: actions/checkout@v1
       - name: Build and upload

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,11 +22,11 @@ jobs:
         run: changelog-tool verify
 
   vs-ponyc-release:
-    name: Verify PR builds against ponyc:release
+    name: Verify PR builds most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/ponyc:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
     steps:
       - uses: actions/checkout@v1
-      - name: Test with ponyc:release
+      - name: Test with most recent ponyc release
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and upload to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
     steps:
       - uses: actions/checkout@v1
       - name: Build and upload


### PR DESCRIPTION
We want to make sure that:

- All releases are done in an environment that has been tested by
- Doing nightly releases that run in an environment that has been tested by
- Testing for CI

For changelog-tool that means the shared docker x86 linux builder
image which has `release` and `latest` versions that correspond to
latest ponyc versions.