### PR TITLE
Fix broken automated release process

### DIFF
--- a/.ci-scripts/release/announce-a-release.bash
+++ b/.ci-scripts/release/announce-a-release.bash
@@ -15,7 +15,6 @@
 # - jq
 
 set -o errexit
-set -o nounset
 
 # Pull in shared configuration specific to this repo
 base=$(dirname "$0")
@@ -61,6 +60,10 @@ if [[ -z "${ZULIP_TOKEN}" ]]; then
   echo -e "\e[31mA Zulip access token needs to be set in ZULIP_TOKEN. Exiting."
   exit 1
 fi
+
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
 
 # Set up .netrc file with GitHub credentials
 cat <<- EOF > $HOME/.netrc

--- a/.ci-scripts/release/build-docker-images-on-release.bash
+++ b/.ci-scripts/release/build-docker-images-on-release.bash
@@ -13,7 +13,6 @@
 # - docker
 
 set -o errexit
-set -o nounset
 
 # Pull in shared configuration specific to this repo
 base=$(dirname "$0")
@@ -40,6 +39,10 @@ if [[ -z "${GITHUB_REPOSITORY}" ]]; then
   echo -e "\e[31mExiting."
   exit 1
 fi
+
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
 
 # We aren't validating TAG is in our x.y.z format but we could.
 # For now, TAG validating is left up to the configuration in

--- a/.ci-scripts/release/start-a-release.bash
+++ b/.ci-scripts/release/start-a-release.bash
@@ -18,7 +18,6 @@
 # - git
 
 set -o errexit
-set -o nounset
 
 # Pull in shared configuration specific to this repo
 base=$(dirname "$0")
@@ -28,13 +27,16 @@ source "${base}/config.bash"
 # We validate all that need to be set in case, in an absolute emergency,
 # we need to run this by hand. Otherwise the GitHub actions environment should
 # provide all of these if properly configured
-if [[ -z "${GITHUB_ACTOR}" ]]; then
-  echo -e "\e[31mName of the user to make changes to repo as need to be set in GITHUB_ACTOR. Exiting."
-  exit 1
-fi
-
-if [[ -z "${GITHUB_TOKEN}" ]]; then
-  echo -e "\e[31mA personal access token needs to be set in GITHUB_TOKEN. Exiting."
+if [[ -z "${RELEASE_TOKEN}" ]]; then
+  echo -e "\e[31mA personal access token needs to be set in RELEASE_TOKEN."
+  echo -e "\e[31mIt should not be secrets.GITHUB_TOKEN. It has to be a"
+  echo -e "\e[31mpersonal access token otherwise next steps in the release"
+  echo -e "\e[31mprocess WILL NOT trigger."
+  echo -e "\e[31mPersonal access tokens are in the form:"
+  echo -e "\e[31m     USERNAME:TOKEN"
+  echo -e "\e[31mfor example:"
+  echo -e "\e[31m     ponylang-main:1234567890"
+  echo -e "\e[31mExiting."
   exit 1
 fi
 
@@ -55,21 +57,16 @@ if [[ -z "${GITHUB_REPOSITORY}" ]]; then
   exit 1
 fi
 
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
+
 # Set up .netrc file with GitHub credentials
-cat <<- EOF > $HOME/.netrc
-      machine github.com
-      login $GITHUB_ACTOR
-      password $GITHUB_TOKEN
-      machine api.github.com
-      login $GITHUB_ACTOR
-      password $GITHUB_TOKEN
-EOF
-
-chmod 600 $HOME/.netrc
-
 git config --global user.name 'Ponylang Main Bot'
 git config --global user.email 'ponylang.main@gmail.com'
 git config --global push.default simple
+
+PUSH_TO="https://${ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 # Extract version from tag reference
 # Tag ref version: "refs/tags/release-1.0.0"
@@ -101,9 +98,9 @@ git tag "${VERSION}"
 
 # push to release to remote
 echo -e "\e[34mPushing commited changes back to master"
-git push origin master
+git push ${PUSH_TO} master
 echo -e "\e[34mPushing ${VERSION} tag"
-git push origin "${VERSION}"
+git push ${PUSH_TO} "${VERSION}"
 
 # pull again, just in case, odds of this being needed are really slim
 git pull
@@ -118,8 +115,8 @@ git add CHANGELOG.md
 git commit -m "Add unreleased section to CHANGELOG post ${VERSION} release [skip ci]"
 
 echo -e "\e[34mPushing CHANGELOG.md"
-git push origin master
+git push ${PUSH_TO} master
 
 # delete release-VERSION tag
 echo -e "\e[34mDeleting no longer needed remote tag release-${VERSION}"
-git push --delete origin "release-${VERSION}"
+git push --delete ${PUSH_TO} "release-${VERSION}"

--- a/.ci-scripts/release/trigger-release-announcement.bash
+++ b/.ci-scripts/release/trigger-release-announcement.bash
@@ -15,7 +15,6 @@
 # - git
 
 set -o errexit
-set -o nounset
 
 # Pull in shared configuration specific to this repo
 base=$(dirname "$0")
@@ -25,13 +24,16 @@ source "${base}/config.bash"
 # We validate all that need to be set in case, in an absolute emergency,
 # we need to run this by hand. Otherwise the GitHub actions environment should
 # provide all of these if properly configured
-if [[ -z "${GITHUB_ACTOR}" ]]; then
-  echo -e "\e[31mName of the user to make changes to repo as need to be set in GITHUB_ACTOR. Exiting."
-  exit 1
-fi
-
-if [[ -z "${GITHUB_TOKEN}" ]]; then
-  echo -e "\e[31mA personal access token needs to be set in GITHUB_TOKEN. Exiting."
+if [[ -z "${RELEASE_TOKEN}" ]]; then
+  echo -e "\e[31mA personal access token needs to be set in RELEASE_TOKEN."
+  echo -e "\e[31mIt should not be secrets.GITHUB_TOKEN. It has to be a"
+  echo -e "\e[31mpersonal access token otherwise next steps in the release"
+  echo -e "\e[31mprocess WILL NOT trigger."
+  echo -e "\e[31mPersonal access tokens are in the form:"
+  echo -e "\e[31m     USERNAME:TOKEN"
+  echo -e "\e[31mfor example:"
+  echo -e "\e[31m     ponylang-main:1234567890"
+  echo -e "\e[31mExiting."
   exit 1
 fi
 
@@ -44,21 +46,15 @@ if [[ -z "${GITHUB_REF}" ]]; then
   exit 1
 fi
 
-# Set up .netrc file with GitHub credentials
-cat <<- EOF > $HOME/.netrc
-      machine github.com
-      login $GITHUB_ACTOR
-      password $GITHUB_TOKEN
-      machine api.github.com
-      login $GITHUB_ACTOR
-      password $GITHUB_TOKEN
-EOF
-
-chmod 600 $HOME/.netrc
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
 
 git config --global user.name 'Ponylang Main Bot'
 git config --global user.email 'ponylang.main@gmail.com'
 git config --global push.default simple
+
+PUSH_TO="https://${ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 # Extract version from tag reference
 # Tag ref version: "refs/tags/1.0.0"
@@ -71,4 +67,4 @@ git tag "announce-${VERSION}"
 
 # push tag
 echo -e "\e[34mPushing announce-${VERSION} tag"
-git push origin "announce-${VERSION}"
+git push ${PUSH_TO} "announce-${VERSION}"

--- a/.ci-scripts/release/x86-64-unknown-linux.bash
+++ b/.ci-scripts/release/x86-64-unknown-linux.bash
@@ -15,7 +15,6 @@
 # - GNU tar
 
 set -o errexit
-set -o nounset
 
 # Pull in shared configuration specific to this repo
 base=$(dirname "$0")
@@ -59,6 +58,10 @@ if [[ -z "${CLOUDSMITH_REPO}" ]]; then
   echo -e "\e[31mExiting."
   exit 1
 fi
+
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
 
 TODAY=$(date +%Y%m%d)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Trigger release announcement
         run: bash .ci-scripts/release/trigger-release-announcement.bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/start-a-release.yml
+++ b/.github/workflows/start-a-release.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Start release process
         run: bash .ci-scripts/release/start-a-release.bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
1 large issue:

Pushing back to GitHub using the supplied GITHUB_TOKEN does not
trigger additional events. What does this mean? When we push back a
release tag like `0.1.0`, the next workflow doesn't trigger.

To address, you have to use a personal access token to trigger.

This commit makes that change.

Additionally, this commit improves error messages from release scripts
by having the error messages actually displayed instead of a generic
unbound variable error message.