### PR TITLE
Use single quotes when adding entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ changelog-tool unreleased -e
 ```
 
 ## Add an entry to an unreleased section
+
 ```bash
-changelog-tool add fixed "We fixed some bad issues" -e
-changelog-tool add added "We just added some new cool stuff" -e
-changelog-tool add changed "And changed things a bit" -e
+changelog-tool add fixed 'We fixed some bad issues' -e
+changelog-tool add added 'We just added some new cool stuff' -e
+changelog-tool add changed 'And changed things a bit' -e
 ```
 
 ## Prepare a Changelog for a Release


### PR DESCRIPTION
It's advised to use single quotes instead of double quotes when adding something to the changelog, specially when we write things like "Fix Corral run only looking for binaries on $PATH".

Running this command:

```
changelog-tool add fixed "Fix Corral run only looking for binaries on $PATH ([PR #56](https://github.com/ponylang/corral/pull/56))" -e
```

Will output this instead:

```
- Fix Corral run only looking for binaries on /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ([PR #56](https://github.com/ponylang/corral/pull/56))
```

We should change the _github action_ that is calling `changelog-tool add fixed "{entry}" -e` to use single quotes!