### PR TITLE
Add repository_dispatch sending and receiving

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -1,16 +1,16 @@
-name: vs-ponyc-latest
+name: ponyc update breakage test
 
 on:
-  schedule:
-    - cron: "0 2 * * *"
+  repository_dispatch:
+    types: [shared-docker-linux-builders-updated]
 
 jobs:
-  vs-ponyc-master:
-    name: Verify master against ponyc master
+  vs-latest-ponyc:
+    name: Verify master against the latest ponyc
     runs-on: ubuntu-latest
     container:
       image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
     steps:
       - uses: actions/checkout@v1
-      - name: Test with against ponyc master
-        run: make test
+      - name: Test with against latest ponyc
+        run: make test config=debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,11 @@ jobs:
         run: bash .ci-scripts/release/build-docker-images-on-release.bash
 
   trigger-release-announcement:
+    needs: [x86-64-unknown-linux-release, x86-64-apple-darwin-release, build-release-docker-images]
+
     name: Trigger release announcement
     runs-on: ubuntu-latest
-    needs: [x86-64-unknown-linux-release, x86-64-apple-darwin-release, build-release-docker-images]
+
     steps:
       - uses: actions/checkout@v1
       - name: Trigger
@@ -61,3 +63,20 @@ jobs:
           git_user_email: "ponylang.main@gmail.com"
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  send-release-event:
+    needs: [x86-64-unknown-linux-release, x86-64-apple-darwin-release, build-release-docker-images]
+
+    name: Send release event
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['ponylang/shared-docker']
+    steps:
+      - name: Send
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.PONYLANG_MAIN_API_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: changelog-tool-released
+          client-payload: '{}'

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A tool for modifying the "standard pony" changelogs.
 
 ## Status
 
-[![Actions Status](https://github.com/ponylang/changelog-tool/workflows/vs-ponyc-latest/badge.svg)](https://github.com/ponylang/changelog-tool/actions)
-
 Production ready.
 
 ## Installation


### PR DESCRIPTION
This commit switches the changelog-tool to using our new cross repository
communication mechanism using GitHub's repository_dispatch events.

With this commit a number of changes will occur:

- Breakage against the latest ponyc version will happen not on a set schedule,
  but instead, after the linux builder image with said changes has been updated.

- Event will be sent (initially only to the shared-docker repo) for when changelog-tool
  releases are done.

This commit requires a change in shared-docker that will turn on sending a repository_dispatch
event when linux builder images are updated.