### PR TITLE
Switch repository-dispatch action to our fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         repo: ['ponylang/shared-docker']
     steps:
       - name: Send
-        uses: peter-evans/repository-dispatch@v1
+        uses: ponylang-main/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4
         with:
           token: ${{ secrets.PONYLANG_MAIN_API_TOKEN }}
           repository: ${{ matrix.repo }}


### PR DESCRIPTION
Using our fork keeps it from changing or disappearing out from
under us.