### PR TITLE
Switch from ponyc release to ponyc nightly

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
       - name: Build and upload
         run: |
           docker run --rm \
@@ -24,7 +24,7 @@ jobs:
             -w /root/project \
             -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly \
             bash .ci-scripts/release/arm64-unknown-linux-nightly.bash
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -42,7 +42,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,12 +18,12 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-release:
-    name: Verify PR builds most recent ponyc release
+  vs-ponyc-nightly:
+    name: Verify PR builds most recent ponyc nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
       - name: Build and upload
         run: |
           docker run --rm \
@@ -55,7 +55,7 @@ jobs:
             -w /root/project \
             -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly \
             bash .ci-scripts/release/arm64-unknown-linux-release.bash
 
   x86-64-unknown-linux-release:
@@ -64,7 +64,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ponylang/ponyc:release AS build
+FROM ghcr.io/ponylang/ponyc:nightly AS build
 
 WORKDIR /src/changelog-tool
 

--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/peg.git",
-      "version": "0.1.6"
+      "version": "0.1.7"
     }
   ],
   "info": {}


### PR DESCRIPTION
The latest ponyc nightly now errors on unreachable else clauses in exhaustive matches. The peg dependency had three instances of this, fixed in peg 0.1.7. Bumping peg and switching all CI jobs and the Dockerfile to use the nightly ponyc builder so we track nightly going forward.