### PR TITLE
Use Makefile-built binary in verification.sh instead of rebuilding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test: $(binary)
 	cd tests && \
 		$(COMPILE_WITH) -d -V1 && ./tests && \
 		rm tests && \
-		sh verification.sh && \
+		sh verification.sh ../$(binary) && \
 		cd ..
 
 clean:

--- a/tests/verification.sh
+++ b/tests/verification.sh
@@ -8,16 +8,14 @@ echo_green() {
   printf "\x1b[32;1m%s\x1b[0m\n" "$1"
 }
 
-corral run -- ponyc -d -V1 ../changelog-tool -b changelog-tool
+CHANGELOG_TOOL=$1
 
 for f in bad-changelogs/*.md; do
-  if ./changelog-tool verify -f="$f"; then
+  if "$CHANGELOG_TOOL" verify -f="$f"; then
     echo_red "changelog-tool failed to catch bad changelog: $f"
     exit 1
   fi
 done
-
-rm changelog-tool
 
 printf "\n"
 echo_green "All verification tests have passed."


### PR DESCRIPTION

## Context

The test scripts build their own `changelog-tool` binary independently of the main Makefile, making them brittle and out of step with the rest of the build process.

## Changes

- `verification.sh` now accepts the binary path as an argument (`$1`) instead of running its own `corral run -- ponyc` build and cleanup
- `Makefile` passes `../$(binary)` to `verification.sh`, so it uses the same binary the `test` target already built

## Consequences

Resolves #43.