### PR TITLE
Write .sha512 siblings in binary mode for cross-platform parity

### DIFF
--- a/.ci-scripts/release/github_release.py
+++ b/.ci-scripts/release/github_release.py
@@ -90,8 +90,11 @@ def write_sha512_sibling(archive_path):
         for chunk in iter(lambda: f.read(1024 * 1024), b''):
             h.update(chunk)
     sibling_path = archive_path + '.sha512'
-    with open(sibling_path, 'w') as f:
-        f.write(h.hexdigest() + '\n')
+    # Binary mode: keep the digest file byte-identical across platforms.
+    # Text mode on Windows would rewrite '\n' as '\r\n' and produce Windows
+    # archives with CRLF-terminated siblings while Linux/macOS produce LF.
+    with open(sibling_path, 'wb') as f:
+        f.write((h.hexdigest() + '\n').encode('ascii'))
     return sibling_path
 
 


### PR DESCRIPTION
Python text mode on Windows translates `\n` to `\r\n`, so Windows-built archives would get CRLF-terminated `.sha512` siblings while Linux/macOS produce LF. Future consumers (see ponyup discussion #405) byte-compare the file, so the asymmetry is a latent portability bug.

changelog-tool has no Windows release jobs today, so this is defensive. Applied for consistency with the same script duplicated across corral, ponyup, and ponyc (ponylang/ponyc#5233) pending centralization.

Smoke-tested locally: output is `<hex>\n` (129 bytes), byte-identical to `hashlib.sha512(archive_bytes).hexdigest() + '\n'` encoded as ascii, LF-only with no CR.