### PR TITLE
Pass DELETE_PACKAGE_TOKEN to container-retention-policy

### DIFF
--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -50,7 +50,7 @@ jobs:
         uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
         with:
           account: ponylang
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DELETE_PACKAGE_TOKEN }}
           image-names: changelog-tool
           tag-selection: untagged
           cut-off: 1d


### PR DESCRIPTION
GitHub's new installation-token format (longer `ghs_` JWT with hyphens) fails `snok/container-retention-policy`'s hardcoded token regex; the action is unmaintained at v3.0.1. Use the org-wide `DELETE_PACKAGE_TOKEN` classic PAT, whose format isn't changing.