### PR TITLE
Use DELETE_PACKAGES_TOKEN (plural), not DELETE_PACKAGE_TOKEN

### DIFF
--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -50,7 +50,7 @@ jobs:
         uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
         with:
           account: ponylang
-          token: ${{ secrets.DELETE_PACKAGE_TOKEN }}
+          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
           image-names: changelog-tool
           tag-selection: untagged
           cut-off: 1d


### PR DESCRIPTION
The org secret is named `DELETE_PACKAGES_TOKEN`. The previous PR referenced the singular form, which resolved to empty at runtime and caused the prune step to fail with "token value is not valid".