### PR TITLE
Add Python linting on PR

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,23 @@
+name: Lint Python Scripts
+
+on: pull_request
+
+concurrency:
+  group: lint-python-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Check Python files under .ci-scripts/
+        # ruff 0.15.12
+        uses: docker://ghcr.io/astral-sh/ruff@sha256:e42f3866bb9f701dbc459cdec3f5aca06511e6a38e6e04bfd4d04a2be26d4fd4
+        with:
+          args: check .ci-scripts


### PR DESCRIPTION
Adds `.github/workflows/lint-python.yml`, modeled on ponyup's lint-python workflow. It runs `ruff check .ci-scripts` on every pull request using the pinned `docker://ghcr.io/astral-sh/ruff` action, covering both `github_release.py` and `ghcr_nightly.py`.

ruff (the exact pinned image) and actionlint both pass against the current tree.

Closes #141
Closes #130