### PR TITLE
Add arm64-unknown-linux-release to send-release-event needs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
 
   send-release-event:
     needs:
+      - arm64-unknown-linux-release
       - x86-64-unknown-linux-release
       - build-release-docker-images
     name: Send release event


### PR DESCRIPTION
## Summary

Fixes #128 — adds `arm64-unknown-linux-release` to the `send-release-event` job's `needs:` list so an arm64 linux build failure blocks the release event being sent to `ponylang/shared-docker`.

The `trigger-release-announcement` job already lists both linux builds. This change brings `send-release-event` in line with that pattern.

## Diff

```diff
   send-release-event:
     needs:
+      - arm64-unknown-linux-release
       - x86-64-unknown-linux-release
       - build-release-docker-images
```

## Verification

- `git diff` shows only the one-line addition.
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `actionlint` (the same tool `lint-action-workflows.yml` runs in CI) passes on `release.yml` and across all workflows — no pre-existing or new findings.
- Post-change `send-release-event.needs` equals `trigger-release-announcement.needs`.

## AI-assisted disclosure

Pair-developed with Claude Code (Anthropic Opus 4.7). I read the issue, located the job in `release.yml`, applied the single-line fix, and verified parse + ordering consistency. Per `pony-code-review` SKILL.md ("Not for one-line config changes or typo fixes — ask permission to skip review for those"), the full code-review ensemble was skipped for this one-line YAML change.